### PR TITLE
Customize the tracker object

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,22 @@ You can set the Google Analytics tracking ID using the plugins configuration in 
     }
 }
 ```
+
+You can customize the tracker object by passing additional configuration options. You can either pass in `auto`, `none` or an object:
+
+```
+{
+    "plugins": ["ga"],
+    "pluginsConfig": {
+        "ga": {
+            "token": "UA-XXXX-Y",
+            "configuration": {
+                "cookieName": "new_cookie_name",
+                "cookieDomain": "mynew.domain.com"
+            }
+        }
+    }
+}
+```
+
+For an overview of all available configuration parameters, please refer to the [analytics.js field reference](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#create).

--- a/index.js
+++ b/index.js
@@ -7,13 +7,27 @@ module.exports = {
         html: {
             "body:end": function() {
                 var config = this.options.pluginsConfig.ga || {};
-                if (!config.token) throw "Need to option 'token' for Google Analytics plugin";
+                
+                if (!config.token) {
+                	throw "Need to option 'token' for Google Analytics plugin";
+                }
+                
+                if (!config.configuration) {
+                	config.configuration = 'auto';
+                }
+
+                if(typeof config.configuration === 'object' && config.configuration !== null) {
+                	configuration = JSON.stringify(config.configuration);
+                }
+                else if (['auto', 'none'].indexOf(config.configuration) != -1) {
+                	configuration = "'" + config.configuration + "'";
+                }
 
                 return "<script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){"
                 + "(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),"
                 + "m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)"
                 + "})(window,document,'script','//www.google-analytics.com/analytics.js','ga');"
-                + "ga('create', '"+config.token+"', 'auto');"
+                + "ga('create', '"+config.token+"', "+configuration+");"
                 + "ga('send', 'pageview');</script>";
             }
         }


### PR DESCRIPTION
Hi,

This pull requests adds an extra configuration parameter to fully customise the tracker object. This is required especially if you need to add support for tracking across multiple domains. 

See: [Advanced Configuration](https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced#customizeTracker) and [Domains & Cookies](https://developers.google.com/analytics/devguides/collection/analyticsjs/domains)

Thanks for this useful plugin!

Cheers,
Steven
