### PR TITLE
Update plugin.js

### DIFF
--- a/book/plugin.js
+++ b/book/plugin.js
@@ -4,7 +4,7 @@ require(["gitbook"], function(gitbook) {
     });
 
     gitbook.events.bind("page.change", function() {
-        ga('send', 'pageview');
+        ga('send', 'pageview', window.location.pathname+window.location.search);
     });
 
     gitbook.events.bind("exercise.submit", function(e, data) {


### PR DESCRIPTION
Fix page tracking in Google Analytics - currently it doesn't show the correct page after navigating the Gitbook. This forced page location tag should fix it.
